### PR TITLE
Add: reserve listing feature

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,8 @@ gem 'omniauth-facebook'
 gem "paperclip", "~> 5.0.0"
 gem 'dropzonejs-rails'
 gem 'geocoder'
+gem 'jquery-ui-rails'
+gem 'simple_form'
 
 group :development, :test do
 	gem 'sqlite3', '1.3.13'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,6 +107,8 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
+    jquery-ui-rails (6.0.1)
+      railties (>= 3.2.16)
     jwt (1.5.6)
     listen (3.0.8)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -231,6 +233,9 @@ GEM
       tilt (>= 1.1, < 3)
     shoulda-matchers (3.1.2)
       activesupport (>= 4.0.0)
+    simple_form (3.5.0)
+      actionpack (> 4, < 5.2)
+      activemodel (> 4, < 5.2)
     slop (3.6.0)
     spring (2.0.2)
       activesupport (>= 4.2)
@@ -291,6 +296,7 @@ DEPENDENCIES
   geocoder
   jbuilder (= 2.6.4)
   jquery-rails (= 4.3.1)
+  jquery-ui-rails
   listen (~> 3.0.5)
   omniauth
   omniauth-facebook
@@ -306,6 +312,7 @@ DEPENDENCIES
   rspec-rails
   sass-rails (= 5.0.6)
   shoulda-matchers
+  simple_form
   spring
   spring-commands-rspec (= 1.0.4)
   spring-watcher-listen

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -14,6 +14,8 @@
 //= require dropzone
 //= require bootstrap-sprockets
 //= require toastr
+//= require jquery-ui/widgets/datepicker
+//= require jquery-ui/i18n/datepicker-ja
 //= require jquery_ujs
 //= require turbolinks
 //= require_tree .

--- a/app/assets/javascripts/datepicker.js
+++ b/app/assets/javascripts/datepicker.js
@@ -1,0 +1,16 @@
+// // datepicker for listing reservation calendar
+$(function() {
+	$("#reservation_start_date").datepicker({
+		format: 'YYYY-MM-DD',
+		language: 'ja'
+	}).on('dp.error', function(e) {
+		$(e.target).val('');
+	});
+
+	$("#reservation_end_date").datepicker({
+		format: 'YYYY-MM-DD',
+		language: 'ja'
+	}).on('dp.error', function(e) {
+		$(e.target).val('');
+	});
+});

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -12,6 +12,7 @@
  *
  *= require toastr
  *= require dropzone/dropzone
+ *= require jquery-ui/datepicker
  *= require_tree .
  *= require_self
  */

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -366,10 +366,19 @@ span.listing-title {
 	padding: 0;
 }
 
-/* listing/show nearby listings */
-.panel-listing img {
-	width: 100%;
-	height: 100px;
+/* listings/show */
+.listing-show {
+	margin-top: -20px;
+	background: none;
+}
+
+.listing-photos {
+	height:420px; width:100%;
+	overflow:hidden;
+}
+
+.price-pernight {
+	font-size:16px;
 }
 
 /* listings/show for desktop */
@@ -391,6 +400,12 @@ span.listing-title {
 	position: absolute;
 	bottom: 125px;
 	padding: 7px 10px;
+}
+
+/* google map */
+#map {
+	width: 100%;
+	height: 350px;
 }
 
 a {

--- a/app/assets/stylesheets/jquery-bootstrap-datepicker.css
+++ b/app/assets/stylesheets/jquery-bootstrap-datepicker.css
@@ -1,0 +1,115 @@
+.ui-datepicker {
+	background-color: #fff;
+	border: 1px solid #66AFE9;
+	border-radius: 4px;
+	box-shadow: 0 0 8px rgba(102,175,233,.6);
+	display: none;
+	margin-top: 4px;
+	padding: 10px;
+	width: 240px;
+}
+.ui-datepicker a,
+.ui-datepicker a:hover {
+	text-decoration: none;
+}
+.ui-datepicker a:hover,
+	.ui-datepicker td:hover a {
+	color: #2A6496;
+	-webkit-transition: color 0.1s ease-in-out;
+	-moz-transition: color 0.1s ease-in-out;
+	-o-transition: color 0.1s ease-in-out;
+	transition: color 0.1s ease-in-out;
+}
+.ui-datepicker .ui-datepicker-header {
+	margin-bottom: 4px;
+	text-align: center;
+}
+.ui-datepicker .ui-datepicker-title {
+	font-weight: 700;
+}
+.ui-datepicker .ui-datepicker-prev,
+	.ui-datepicker .ui-datepicker-next {
+	cursor: default;
+	font-family: 'Glyphicons Halflings';
+	-webkit-font-smoothing: antialiased;
+	font-style: normal;
+	font-weight: normal;
+	height: 20px;
+	line-height: 1;
+	margin-top: 2px;
+	width: 30px;
+}
+.ui-datepicker .ui-datepicker-prev {
+	float: left;
+	text-align: left;
+}
+.ui-datepicker .ui-datepicker-next {
+	float: right;
+	text-align: right;
+}
+
+.ui-datepicker .ui-icon {
+	display: none;
+}
+.ui-datepicker .ui-datepicker-calendar {
+	table-layout: fixed;
+	width: 100%;
+}
+.ui-datepicker .ui-datepicker-calendar th,
+	.ui-datepicker .ui-datepicker-calendar td {
+	text-align: center;
+	padding: 4px 0;
+}
+.ui-datepicker .ui-datepicker-calendar td {
+	-webkit-transition: background-color 0.1s ease-in-out, color 0.1s ease-in-out;
+	-moz-transition: background-color 0.1s ease-in-out, color 0.1s ease-in-out;
+	-o-transition: background-color 0.1s ease-in-out, color 0.1s ease-in-out;
+	transition: background-color 0.1s ease-in-out, color 0.1s ease-in-out;
+}
+.ui-datepicker .ui-datepicker-calendar td:hover {
+	background-color: #d9534f;
+	cursor: pointer;
+}
+.ui-datepicker .ui-datepicker-calendar td a {
+	text-decoration: none;
+}
+.ui-datepicker .ui-datepicker-current-day {
+	background-color: #4289cc;
+}
+.ui-datepicker .ui-datepicker-current-day a {
+	color: #fff
+}
+.ui-datepicker .ui-datepicker-calendar .ui-datepicker-unselectable:hover {
+	background-color: #eee;
+	cursor: default;
+}
+
+.ui-datepicker .ui-datepicker-calendar td:hover a{
+	color: #fff;
+	cursor: pointer;
+}
+
+.ui-datepicker-calendar{
+	font-size: 14px!important;
+	font-weight: bold;
+}
+
+.ui-datepicker td a {
+	color: #565A4C;
+}
+
+.ui-datepicker .ui-datepicker-calendar .ui-datepicker-unselectable span{
+	color: #ccc   ;
+}
+
+.ui-datepicker .ui-datepicker-next {
+	color: #565A4C;
+}
+
+.ui-datepicker .ui-datepicker-prev {
+	color: #565A4C;
+}
+
+.ui-datepicker .ui-datepicker-current-day {
+	background-color: #d9534f;
+}

--- a/app/controllers/listings_controller.rb
+++ b/app/controllers/listings_controller.rb
@@ -3,6 +3,9 @@ class ListingsController < ApplicationController
 	before_action :set_listing, only: [:show, :update, :basics, :description,
 			:address, :price, :photos, :calendar, :bankaccount,
 			:publish, :destroy]
+	before_action :is_own_listing?, only: [:show, :update, :basics, :description,
+			:address, :price, :photos, :calendar, :bankaccount,
+			:publish, :destroy]
 
 	def index
 		@listings = current_user.listings
@@ -77,6 +80,9 @@ end
 
 		def set_listing
 			@listing = Listing.find_by(id: params[:id])
+		end
+
+		def is_own_listing?
 			unless current_user.listings.include?(@listing)
 				redirect_to root_path, alert: "リスティング情報は見つかりませんでした。"
 			end

--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -1,0 +1,16 @@
+class ReservationsController < ApplicationController
+
+	def create
+		@reservation = current_user.reservations.new(reservation_params)
+		if @reservation.save
+			redirect_to @reservation.listing, notice: "予約が完了しました。"
+		else
+			redirect_to @reservation.listing, alert: "予約に失敗しました。もう一度予約してください。"
+		end
+	end
+
+	private
+		def reservation_params
+			params.require(:reservation).permit(:start_date, :end_date, :listing_id)
+		end
+end

--- a/app/models/listing.rb
+++ b/app/models/listing.rb
@@ -1,6 +1,7 @@
 class Listing < ActiveRecord::Base
 	belongs_to :user
 	has_many :photos, dependent: :destroy
+	has_many :reservations, dependent: :destroy
 
 	validates :house_type, presence: true
 	validates :house_years, presence: true

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -1,0 +1,7 @@
+class Reservation < ApplicationRecord
+	belongs_to :user
+	belongs_to :listing
+
+	validates :start_date, presence: true
+	validates :end_date, presence: true
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,7 @@ class User < ActiveRecord::Base
 			:recoverable, :rememberable, :trackable, :validatable, :omniauthable
 
 		has_many :listings, dependent: :destroy
+		has_many :reservations, dependent: :destroy
 
 		def self.from_omniauth(auth)
 			where(provider: auth.provider, uid: auth.uid).first_or_create do |user|

--- a/app/views/listings/show.html.erb
+++ b/app/views/listings/show.html.erb
@@ -1,6 +1,6 @@
 <%= render 'partials/navbar' %>
 
-<div class="jumbotron row-space-0" style="margin-top: -20px; background: none;">
+<div class="jumbotron row-space-0 listing-show">
 	<div id="myCarousel" class="carousel slide" data-ride="carousel">
 
 		<% if @photos.length > 1 %>
@@ -15,7 +15,7 @@
 			<% if @photos %>
 				<% @photos.each do |photo| %>
 					<div class="item <%= 'active' if photo.id == @photos[0].id %>">
-						<%= image_tag photo.image.url(),style: "height:420px; width:100%; overflow:hidden;" %>
+						<%= image_tag photo.image.url(), class:"listing-photos" %>
 					</div>
 				<% end %>
 			<% end %>
@@ -56,30 +56,39 @@
 							<h5><%= @listing.house_type %></h5>
 						</div>
 						<div class="col-sm-3 col-xs-3 text-center">
-							<i class="fa fa-linux fa-3x" aria-hidden="true"></i>
-							<h5><%= @listing.house_type %></h5>
-						</div>
-						<div class="col-sm-3 col-xs-3 text-center">
-							<i class="fa fa-bug fa-3x" aria-hidden="true"></i>
+							<i class="fa fa-male fa-3x" aria-hidden="true"></i>
 							<h5><%= @listing.house_size %></h5>
 						</div>
 						<div class="col-sm-3 col-xs-3 text-center">
 							<i class="fa fa-clock-o fa-3x" aria-hidden="true"></i>
-							<h5><%= @listing.house_years %>年</h5>
+							<h5>築<%= @listing.house_years %>年</h5>
 						</div>
 					</div>
 				</div>
 
+				<!-- reservation form -->
 				<div class="col-md-3">
 					<div class="panel panel-default panel-show">
 						<div class="panel-heading">
-								<span class="price-per-night"><%= @listing.price_pernight %>円（一晩あたり）</span>
+								<span class="price-pernight"><%= @listing.price_pernight %>円（一晩あたり）</span>
 						</div>
-
+						
 						<div class="panel-body panel-real">
-							<%= form_for @listing, :html => { multipart: true } do |f| %>
+							<%= simple_form_for [@listing, @listing.reservations.new] do |f| %>
+
+								<%= f.input :listing_id, as: :hidden %>
+
+								<div class="row row-space-2">
+									<%= f.input :start_date, label: "チェックイン", as: :string, 
+										placeholder: "開始日", wrapper_html: { class: "col-md-6" },
+										input_html: { class: "form-control" } %>
+
+									<%= f.input :end_date, label: "チェックアウト", as: :string,
+										placeholder: "終了日", wrapper_html: { class: "col-md-6" },
+										input_html: { class: "form-control" } %>
+								</div>
 								<div class="actions text-center">
-									<%= f.submit "この日程で予約する", class: "btn btn-success btn-wide" %>
+									<%= f.button :submit, "この日程で予約する", class: "btn btn-primary btn-wide" %>
 								</div>
 							<% end %>
 						</div>
@@ -94,7 +103,7 @@
 <div class="container">
 	<div class="row">
 		<div class="col-md-9">
-			<h3 class="row-space-3">このリスティングについて</h3>
+			<h3 class="row-space-3">宿泊先詳細情報</h3>
 				<p>
 					<%= @listing.listing_content %>
 				</p>
@@ -103,16 +112,7 @@
 		</div>
 	</div>
 
-	<!-- review    -->
-	<div class="row">
-		<div class="col-md-9">
-			<h3 class="row-space-3">レビュー</h3>
-		</div>
-		<div class="col-md-3">
-		</div>
-	</div>
-
-	<!-- google map    -->
+	<!-- google map -->
 	<div class="row">
 		<div class="col-md-9">
 			<h3>アクセス</h3>
@@ -120,45 +120,8 @@
 		</div>
 		<div class="col-md-3">
 		</div>
-		<style type="text/css">
-			#map {
-				width: 100%;
-				height: 350px;
-			}
-		</style>
 	</div>
 
-	<!-- around listing  -->
-	<div class="row">
-		<div class="col-md-9">
-			<h3 class="row-space-3">近くのリスティング</h3>
-			<% for listing in @listing.nearbys(10) %>
-				<div class="col-md-3">
-					<div class="panel panel-default">
-						<div class="panel-heading panel-lising text-center">
-							<% link_to(listing) do %>
-								<%= image_tag listing.photos[0].image.url(:medium) if listing.photos.length > 0 %>
-							<% end %>
-						</div>
-
-						<div class="panel-body">
-							<div class="col-md-9 col-md-3-xs-8">
-								<%= link_to listing.listing_title, listing %><br>
-							</div>
-							<div class="col-md-3 col-xs-3">
-								<%= image_tag listing.user.image, class: "img-circle profile-1" %>
-							</div>
-							<div class="price-card">
-								<%= listing.price_pernight %>円
-							</div>
-						</div>
-					</div>
-				</div>
-			<% end %>
-		</div>
-		<div class="col-md-3">
-		</div>
-	</div>
 </div>
 <script>
 	function initMap() {

--- a/config/initializers/simple_form.rb
+++ b/config/initializers/simple_form.rb
@@ -1,0 +1,169 @@
+# Use this setup block to configure all options available in SimpleForm.
+SimpleForm.setup do |config|
+  # Wrappers are used by the form builder to generate a
+  # complete input. You can remove any component from the
+  # wrapper, change the order or even add your own to the
+  # stack. The options given below are used to wrap the
+  # whole input.
+  config.wrappers :default, class: :input,
+    hint_class: :field_with_hint, error_class: :field_with_errors do |b|
+    ## Extensions enabled by default
+    # Any of these extensions can be disabled for a
+    # given input by passing: `f.input EXTENSION_NAME => false`.
+    # You can make any of these extensions optional by
+    # renaming `b.use` to `b.optional`.
+
+    # Determines whether to use HTML5 (:email, :url, ...)
+    # and required attributes
+    b.use :html5
+
+    # Calculates placeholders automatically from I18n
+    # You can also pass a string as f.input placeholder: "Placeholder"
+    b.use :placeholder
+
+    ## Optional extensions
+    # They are disabled unless you pass `f.input EXTENSION_NAME => true`
+    # to the input. If so, they will retrieve the values from the model
+    # if any exists. If you want to enable any of those
+    # extensions by default, you can change `b.optional` to `b.use`.
+
+    # Calculates maxlength from length validations for string inputs
+    # and/or database column lengths
+    b.optional :maxlength
+
+    # Calculate minlength from length validations for string inputs
+    b.optional :minlength
+
+    # Calculates pattern from format validations for string inputs
+    b.optional :pattern
+
+    # Calculates min and max from length validations for numeric inputs
+    b.optional :min_max
+
+    # Calculates readonly automatically from readonly attributes
+    b.optional :readonly
+
+    ## Inputs
+    b.use :label_input
+    b.use :hint,  wrap_with: { tag: :span, class: :hint }
+    b.use :error, wrap_with: { tag: :span, class: :error }
+
+    ## full_messages_for
+    # If you want to display the full error message for the attribute, you can
+    # use the component :full_error, like:
+    #
+    # b.use :full_error, wrap_with: { tag: :span, class: :error }
+  end
+
+  # The default wrapper to be used by the FormBuilder.
+  config.default_wrapper = :default
+
+  # Define the way to render check boxes / radio buttons with labels.
+  # Defaults to :nested for bootstrap config.
+  #   inline: input + label
+  #   nested: label > input
+  config.boolean_style = :nested
+
+  # Default class for buttons
+  config.button_class = 'btn'
+
+  # Method used to tidy up errors. Specify any Rails Array method.
+  # :first lists the first message for each field.
+  # Use :to_sentence to list all errors for each field.
+  # config.error_method = :first
+
+  # Default tag used for error notification helper.
+  config.error_notification_tag = :div
+
+  # CSS class to add for error notification helper.
+  config.error_notification_class = 'error_notification'
+
+  # ID to add for error notification helper.
+  # config.error_notification_id = nil
+
+  # Series of attempts to detect a default label method for collection.
+  # config.collection_label_methods = [ :to_label, :name, :title, :to_s ]
+
+  # Series of attempts to detect a default value method for collection.
+  # config.collection_value_methods = [ :id, :to_s ]
+
+  # You can wrap a collection of radio/check boxes in a pre-defined tag, defaulting to none.
+  # config.collection_wrapper_tag = nil
+
+  # You can define the class to use on all collection wrappers. Defaulting to none.
+  # config.collection_wrapper_class = nil
+
+  # You can wrap each item in a collection of radio/check boxes with a tag,
+  # defaulting to :span.
+  # config.item_wrapper_tag = :span
+
+  # You can define a class to use in all item wrappers. Defaulting to none.
+  # config.item_wrapper_class = nil
+
+  # How the label text should be generated altogether with the required text.
+  # config.label_text = lambda { |label, required, explicit_label| "#{required} #{label}" }
+
+  # You can define the class to use on all labels. Default is nil.
+  # config.label_class = nil
+
+  # You can define the default class to be used on forms. Can be overriden
+  # with `html: { :class }`. Defaulting to none.
+  # config.default_form_class = nil
+
+  # You can define which elements should obtain additional classes
+  # config.generate_additional_classes_for = [:wrapper, :label, :input]
+
+  # Whether attributes are required by default (or not). Default is true.
+  # config.required_by_default = true
+
+  # Tell browsers whether to use the native HTML5 validations (novalidate form option).
+  # These validations are enabled in SimpleForm's internal config but disabled by default
+  # in this configuration, which is recommended due to some quirks from different browsers.
+  # To stop SimpleForm from generating the novalidate option, enabling the HTML5 validations,
+  # change this configuration to true.
+  config.browser_validations = false
+
+  # Collection of methods to detect if a file type was given.
+  # config.file_methods = [ :mounted_as, :file?, :public_filename ]
+
+  # Custom mappings for input types. This should be a hash containing a regexp
+  # to match as key, and the input type that will be used when the field name
+  # matches the regexp as value.
+  # config.input_mappings = { /count/ => :integer }
+
+  # Custom wrappers for input types. This should be a hash containing an input
+  # type as key and the wrapper that will be used for all inputs with specified type.
+  # config.wrapper_mappings = { string: :prepend }
+
+  # Namespaces where SimpleForm should look for custom input classes that
+  # override default inputs.
+  # config.custom_inputs_namespaces << "CustomInputs"
+
+  # Default priority for time_zone inputs.
+  # config.time_zone_priority = nil
+
+  # Default priority for country inputs.
+  # config.country_priority = nil
+
+  # When false, do not use translations for labels.
+  # config.translate_labels = true
+
+  # Automatically discover new inputs in Rails' autoload path.
+  # config.inputs_discovery = true
+
+  # Cache SimpleForm inputs discovery
+  # config.cache_discovery = !Rails.env.development?
+
+  # Default class for inputs
+  # config.input_class = nil
+
+  # Define the default class of the input wrapper of the boolean input.
+  config.boolean_label_class = 'checkbox'
+
+  # Defines if the default input wrapper class should be included in radio
+  # collection wrappers.
+  # config.include_default_input_wrapper_class = true
+
+  # Defines which i18n scope will be used in Simple Form.
+  # config.i18n_scope = 'simple_form'
+end

--- a/config/initializers/simple_form_bootstrap.rb
+++ b/config/initializers/simple_form_bootstrap.rb
@@ -1,0 +1,154 @@
+# Use this setup block to configure all options available in SimpleForm.
+SimpleForm.setup do |config|
+  config.error_notification_class = 'alert alert-danger'
+  config.button_class = 'btn btn-default'
+  config.boolean_label_class = nil
+
+  config.wrappers :vertical_form, tag: 'div', class: 'form-group', error_class: 'has-error' do |b|
+    b.use :html5
+    b.use :placeholder
+    b.optional :maxlength
+    b.optional :minlength
+    b.optional :pattern
+    b.optional :min_max
+    b.optional :readonly
+    b.use :label, class: 'control-label'
+
+    b.use :input, class: 'form-control'
+    b.use :error, wrap_with: { tag: 'span', class: 'help-block' }
+    b.use :hint,  wrap_with: { tag: 'p', class: 'help-block' }
+  end
+
+  config.wrappers :vertical_file_input, tag: 'div', class: 'form-group', error_class: 'has-error' do |b|
+    b.use :html5
+    b.use :placeholder
+    b.optional :maxlength
+    b.optional :minlength
+    b.optional :readonly
+    b.use :label, class: 'control-label'
+
+    b.use :input
+    b.use :error, wrap_with: { tag: 'span', class: 'help-block' }
+    b.use :hint,  wrap_with: { tag: 'p', class: 'help-block' }
+  end
+
+  config.wrappers :vertical_boolean, tag: 'div', class: 'form-group', error_class: 'has-error' do |b|
+    b.use :html5
+    b.optional :readonly
+
+    b.wrapper tag: 'div', class: 'checkbox' do |ba|
+      ba.use :label_input
+    end
+
+    b.use :error, wrap_with: { tag: 'span', class: 'help-block' }
+    b.use :hint,  wrap_with: { tag: 'p', class: 'help-block' }
+  end
+
+  config.wrappers :vertical_radio_and_checkboxes, tag: 'div', class: 'form-group', error_class: 'has-error' do |b|
+    b.use :html5
+    b.optional :readonly
+    b.use :label, class: 'control-label'
+    b.use :input
+    b.use :error, wrap_with: { tag: 'span', class: 'help-block' }
+    b.use :hint,  wrap_with: { tag: 'p', class: 'help-block' }
+  end
+
+  config.wrappers :horizontal_form, tag: 'div', class: 'form-group', error_class: 'has-error' do |b|
+    b.use :html5
+    b.use :placeholder
+    b.optional :maxlength
+    b.optional :minlength
+    b.optional :pattern
+    b.optional :min_max
+    b.optional :readonly
+    b.use :label, class: 'col-sm-3 control-label'
+
+    b.wrapper tag: 'div', class: 'col-sm-9' do |ba|
+      ba.use :input, class: 'form-control'
+      ba.use :error, wrap_with: { tag: 'span', class: 'help-block' }
+      ba.use :hint,  wrap_with: { tag: 'p', class: 'help-block' }
+    end
+  end
+
+  config.wrappers :horizontal_file_input, tag: 'div', class: 'form-group', error_class: 'has-error' do |b|
+    b.use :html5
+    b.use :placeholder
+    b.optional :maxlength
+    b.optional :minlength
+    b.optional :readonly
+    b.use :label, class: 'col-sm-3 control-label'
+
+    b.wrapper tag: 'div', class: 'col-sm-9' do |ba|
+      ba.use :input
+      ba.use :error, wrap_with: { tag: 'span', class: 'help-block' }
+      ba.use :hint,  wrap_with: { tag: 'p', class: 'help-block' }
+    end
+  end
+
+  config.wrappers :horizontal_boolean, tag: 'div', class: 'form-group', error_class: 'has-error' do |b|
+    b.use :html5
+    b.optional :readonly
+
+    b.wrapper tag: 'div', class: 'col-sm-offset-3 col-sm-9' do |wr|
+      wr.wrapper tag: 'div', class: 'checkbox' do |ba|
+        ba.use :label_input
+      end
+
+      wr.use :error, wrap_with: { tag: 'span', class: 'help-block' }
+      wr.use :hint,  wrap_with: { tag: 'p', class: 'help-block' }
+    end
+  end
+
+  config.wrappers :horizontal_radio_and_checkboxes, tag: 'div', class: 'form-group', error_class: 'has-error' do |b|
+    b.use :html5
+    b.optional :readonly
+
+    b.use :label, class: 'col-sm-3 control-label'
+
+    b.wrapper tag: 'div', class: 'col-sm-9' do |ba|
+      ba.use :input
+      ba.use :error, wrap_with: { tag: 'span', class: 'help-block' }
+      ba.use :hint,  wrap_with: { tag: 'p', class: 'help-block' }
+    end
+  end
+
+  config.wrappers :inline_form, tag: 'div', class: 'form-group', error_class: 'has-error' do |b|
+    b.use :html5
+    b.use :placeholder
+    b.optional :maxlength
+    b.optional :minlength
+    b.optional :pattern
+    b.optional :min_max
+    b.optional :readonly
+    b.use :label, class: 'sr-only'
+
+    b.use :input, class: 'form-control'
+    b.use :error, wrap_with: { tag: 'span', class: 'help-block' }
+    b.use :hint,  wrap_with: { tag: 'p', class: 'help-block' }
+  end
+
+  config.wrappers :multi_select, tag: 'div', class: 'form-group', error_class: 'has-error' do |b|
+    b.use :html5
+    b.optional :readonly
+    b.use :label, class: 'control-label'
+    b.wrapper tag: 'div', class: 'form-inline' do |ba|
+      ba.use :input, class: 'form-control'
+      ba.use :error, wrap_with: { tag: 'span', class: 'help-block' }
+      ba.use :hint,  wrap_with: { tag: 'p', class: 'help-block' }
+    end
+  end
+  # Wrappers for forms and inputs using the Bootstrap toolkit.
+  # Check the Bootstrap docs (http://getbootstrap.com)
+  # to learn about the different styles for forms and inputs,
+  # buttons and other elements.
+  config.default_wrapper = :vertical_form
+  config.wrapper_mappings = {
+    check_boxes: :vertical_radio_and_checkboxes,
+    radio_buttons: :vertical_radio_and_checkboxes,
+    file: :vertical_file_input,
+    boolean: :vertical_boolean,
+    datetime: :multi_select,
+    date: :multi_select,
+    time: :multi_select
+  }
+end

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -1,0 +1,31 @@
+en:
+  simple_form:
+    "yes": 'Yes'
+    "no": 'No'
+    required:
+      text: 'required'
+      mark: '*'
+      # You can uncomment the line below if you need to overwrite the whole required html.
+      # When using html, text and mark won't be used.
+      # html: '<abbr title="required">*</abbr>'
+    error_notification:
+      default_message: "Please review the problems below:"
+    # Examples
+    # labels:
+    #   defaults:
+    #     password: 'Password'
+    #   user:
+    #     new:
+    #       email: 'E-mail to sign in.'
+    #     edit:
+    #       email: 'E-mail.'
+    # hints:
+    #   defaults:
+    #     username: 'User name to sign in.'
+    #     password: 'No special characters, please.'
+    # include_blanks:
+    #   defaults:
+    #     age: 'Rather not say'
+    # prompts:
+    #   defaults:
+    #     age: 'Select your age'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,10 @@ Rails.application.routes.draw do
 		devise_for :users, controllers: { omniauth_callbacks:  'users/omniauth_callbacks',
 				registrations: 'registrations' }
 
-		resources :listings
+		resources :listings do
+			resources :reservations, only: [:create]
+		end
+
 		resources :users, only: [:show]
 		resources :photos, only: [:create, :destroy] do
 			collection do

--- a/db/migrate/20170826015403_create_reservations.rb
+++ b/db/migrate/20170826015403_create_reservations.rb
@@ -1,0 +1,12 @@
+class CreateReservations < ActiveRecord::Migration[5.0]
+  def change
+	create_table :reservations do |t|
+	  t.references :user, foreign_key: true, null: false
+	  t.references :listing, foreign_key: true, null: false
+	  t.datetime :start_date
+	  t.datetime :end_date
+
+	  t.timestamps
+	end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170817154912) do
+ActiveRecord::Schema.define(version: 20170826015403) do
 
   create_table "listings", force: :cascade do |t|
     t.string   "house_type"
@@ -38,6 +38,17 @@ ActiveRecord::Schema.define(version: 20170817154912) do
     t.integer  "image_file_size"
     t.datetime "image_updated_at"
     t.index ["listing_id"], name: "index_photos_on_listing_id"
+  end
+
+  create_table "reservations", force: :cascade do |t|
+    t.integer  "user_id",    null: false
+    t.integer  "listing_id", null: false
+    t.datetime "start_date"
+    t.datetime "end_date"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["listing_id"], name: "index_reservations_on_listing_id"
+    t.index ["user_id"], name: "index_reservations_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|

--- a/spec/integration_tests/listings/create_listing_spec.rb
+++ b/spec/integration_tests/listings/create_listing_spec.rb
@@ -22,7 +22,7 @@ describe 'listings can be created.' do
 		select "3人用", from: "listing[house_size]"
 		click_button "保存"
 		expect(page).to have_http_status :success
-		# add listing address
+		# add listing description
 		visit manage_listing_description_path(user)
 		expect(page).to have_http_status :success
 		fill_in "listing[listing_title]", with: "hoge hoge Title."
@@ -31,8 +31,14 @@ describe 'listings can be created.' do
 		expect(page).to have_http_status :success
 		# add listing price per night
 		visit manage_listing_price_path(user)
-		fill_in "listing[price_pernight]", with: "2500"
 		expect(page).to have_http_status :success
+		fill_in "listing[price_pernight]", with: "2500"
+		click_button "更新"
+		expect(page).to have_http_status :success
+		# add listing address
+		visit manage_listing_address_path(user)
+		expect(page).to have_http_status :success
+		fill_in "listing[address]", with: "東京都港区六本木6丁目11-1"
 		click_button "更新"
 		expect(page).to have_http_status :success
 	end
@@ -60,7 +66,7 @@ describe 'listings can be created.' do
 		select "1人用", from: "listing[house_size]"
 		click_button "保存"
 		expect(page).to have_http_status :success
-		# add listing address
+		# add listing description
 		visit manage_listing_description_path(user)
 		# expect(page).to have_http_status :success
 		fill_in "listing[listing_title]", with: "fuga fuga Title."
@@ -69,6 +75,10 @@ describe 'listings can be created.' do
 		# add listing price per night
 		visit manage_listing_price_path(user)
 		fill_in "listing[price_pernight]", with: "3000"
+		click_button "更新"
+		# add listing address
+		visit manage_listing_address_path(user)
+		fill_in "listing[address]", with: "東京都港区六本木6丁目11-1"
 		click_button "更新"
 		# another user can not check user's listing edit page
 		unless user

--- a/spec/integration_tests/listings/reserve_listing_spec.rb
+++ b/spec/integration_tests/listings/reserve_listing_spec.rb
@@ -1,0 +1,65 @@
+require 'rails_helper'
+
+describe 'listings can be created.' do
+	let(:user) { create(:user) }
+
+	def login_with_user
+		visit new_user_session_path
+		fill_in "eメール", with: user.email
+		fill_in "パスワード", with: user.password
+		click_on "login"
+		expect(page).to have_http_status :success
+		expect(page).to have_content 'Signed in successfully.'
+	end
+
+	def create_listing
+		visit root_path
+		click_on "ホストになる"
+		select "マンション", from: "listing[house_type]"
+		select "2年", from: "listing[house_years]"
+		select "3人用", from: "listing[house_size]"
+		click_button "保存"
+
+		# add listing address
+		visit manage_listing_description_path(user)
+		fill_in "listing[listing_title]", with: "hoge hoge Title."
+		fill_in "listing[listing_content]", with: "hoge hoge Content."
+		click_button "更新"
+
+		# add listing price per night
+		visit manage_listing_price_path(user)
+		fill_in "listing[price_pernight]", with: "2500"
+		click_button "更新"
+
+		# add listing address
+		visit manage_listing_address_path(user)
+		fill_in "listing[address]", with: "東京都港区六本木6丁目11-1"
+		click_button "更新"
+	end
+
+	it 'can reserve listing with correct date' do
+		login_with_user
+		create_listing
+		sleep 1 # wait 1 sec for load
+		visit listing_path(1)
+		fill_in "reservation[start_date]", with: "2017/01/01"
+		fill_in "reservation[end_date]", with: "2017/01/12"
+		click_button "この日程で予約する"
+		expect(page).to have_http_status :success
+		expect(current_path).to eq listing_path(1)
+		expect(page).to have_content '予約が完了しました。'
+	end
+
+	it 'can not reserve listing with incorrect date' do
+		login_with_user
+		create_listing
+		sleep 1 # wait 1 sec for load
+		visit listing_path(1)
+		fill_in "reservation[start_date]", with: "2017/01/51"
+		fill_in "reservation[end_date]", with: "2017/14/62"
+		click_button "この日程で予約する"
+		expect(current_path).to eq listing_path(1)
+		expect(page).to have_content '予約に失敗しました。もう一度予約してください。'
+	end
+end
+


### PR DESCRIPTION
## 概要
ユーザ（宿泊者）が宿泊先を予約する処理を実装しました。
ユーザ（宿泊者）はリスティング（宿泊先）に対して、カレンダー上から宿泊開始日と宿泊終了日を予約できます。
※予約した宿泊情報の管理画面はまだ作成していません。

## 技術的変更点概要
予約処理を扱うコントローラ（reservations_controller.rb）とモデル（reservation.rb）を追加しました。

ユーザ（宿泊者）がリスティングに対して予約を実行することで、current_user.reservationsを作成します。
予約登録時には下記のパラメータがDBに登録されます。
```
- start_date（宿泊開始日）
- end_date（宿泊終了日）
- listing_id（宿泊対象のリスティングid）
```

予約モデルと既存モデルの関係は下記です。
```
- 予約 : ユーザ ＝ N : 1
- 予約 : リスティング ＝ N : 1
```

## 今回保留した項目
実装優先度の関係で、UI側での予約に対するバリデーション対応を一旦保留しました（予約用カレンダー生成はdatepickerを使用しています）。
```
- ユーザ（宿泊者）が過去の日を予約できないようにする
- ユーザ（宿泊者）が予約済みの日を選択できないようにする
```
