### PR TITLE
[WIP]Delete unnecessary migration

### DIFF
--- a/app/controllers/guest_reservations_controller.rb
+++ b/app/controllers/guest_reservations_controller.rb
@@ -1,0 +1,5 @@
+class GuestReservationsController < ApplicationController
+	def index
+		@listings = current_user.listings.includes(:reservations)
+	end
+end

--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -1,5 +1,9 @@
 class ReservationsController < ApplicationController
 
+	def index
+		@reservations = current_user.reservations
+	end
+
 	def create
 		@reservation = current_user.reservations.new(reservation_params)
 		if @reservation.save

--- a/app/views/guest_reservations/index.html.haml
+++ b/app/views/guest_reservations/index.html.haml
@@ -1,0 +1,24 @@
+= render 'partials/navbar'
+.container
+  .col-md-10.col-md-offset-1
+    .panel.panel-default
+      .panel-heading
+        .text-center
+          %span.guest-reservation-manage-list 宿泊者の予約管理
+      %ul.ul-unstyled
+        - @listings.each do |listing|
+          - listing.reservations.each do |reservation|
+            - if reservation.self_booking == nil
+              %li.panel-body
+                .row-table
+                  .col-md-3.col-sm-3.col-middle.row-space-2
+                    .panel-list-img.text-center
+                      = image_tag reservation.listing.photos[0].image.url(:thumb)
+                  .col-sm-7.col-lg-7.col-middle.row-space-2
+                    %span.listing-title= listing.listing_title
+                  .col-md-2.col-sm-2.col-xs-10.col-middle.row-space-2
+                    = reservation.start_date.strftime('%Y年%m月%d日〜')
+                  .col-md-2.col-sm-2.col-xs-10.col-middle.row-space-2
+                    = link_to user_path(reservation.user) do
+                      = image_tag reservation.user.image, class: "img-circle profile-1"
+                      = reservation.user.name

--- a/app/views/partials/_navbar.html.haml
+++ b/app/views/partials/_navbar.html.haml
@@ -30,7 +30,13 @@
               %span.caret
             %ul.dropdown-menu
               %li
-                = link_to "リスティング一覧", listings_path, id: "profile_edit"
+                = link_to "リスティング一覧", listings_path, id: "listings"
+              %li
+              %li
+                = link_to "宿泊先予約管理", reservations_path, id: "reservations"
+              %li
+              %li
+                = link_to "宿泊者の予約管理", guest_reservations_path, id: "guest_reservations"
               %li
                 = link_to "プロフィール", user_path(current_user), id: "profile"
               %li

--- a/app/views/reservations/index.html.haml
+++ b/app/views/reservations/index.html.haml
@@ -1,0 +1,24 @@
+= render 'partials/navbar'
+.container
+  .col-md-10.col-md-offset-1
+    .panel.panel-default
+      .panel-heading
+        .text-center
+          %span.reservation-manage-list 宿泊先予約管理
+      %ul.ul-unstyled
+        - @reservations.each do |reservation|
+          %li.panel-body
+            .row-table
+              .col-md-3.col-sm-3.col-middle.row-space-2
+                .panel-list-img.text-center
+                - unless reservation.listing.photos.empty?
+                  = image_tag reservation.listing.photos[0].image.url(:thumb)
+              .col-sm-7.col-lg-7.col-middle.row-space-2
+                %span.listing-title= reservation.listing.listing_title
+              .col-md-2.col-sm-2.col-xs-10.col-middle.row-space-2
+                = reservation.start_date.strftime('%Y年%m月%d日〜')
+              .col-md-2.col-sm-2.col-xs-10.col-middle.row-space-2
+                = link_to user_path(reservation.listing.user) do
+                  - unless reservation.listing.photos.empty?
+                    = image_tag reservation.listing.user.image, class: "img-circle profile-1"
+                  = reservation.listing.user.name

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,7 @@
 Rails.application.routes.draw do
+
+  get 'guest_reservation_controller/index'
+
 		root to: 'static_pages#index'
 
 		devise_for :users, controllers: { omniauth_callbacks:  'users/omniauth_callbacks',
@@ -14,6 +17,9 @@ Rails.application.routes.draw do
 				get :list
 			end
 		end
+
+		get '/reservations', to: 'reservations#index'
+		get '/guest-reservations', to: 'guest_reservations#index'
 
 		get 'manage-listings/:id/basics', to: 'listings#basics', as: 'manage_listing_basics'
 		get 'manage-listings/:id/description', to: 'listings#description', as: 'manage_listing_description'

--- a/db/migrate/20170827142343_change_column_to_photos.rb
+++ b/db/migrate/20170827142343_change_column_to_photos.rb
@@ -1,9 +1,0 @@
-class ChangeColumnToPhotos < ActiveRecord::Migration[5.0]
-  def up
-  	change_column :photos, :listing_id, :string, null: false
-  end
-
-  def down
-  	change_column :photos, :listing_id, :string
-  end
-end

--- a/db/migrate/20170828011420_change_column_type_to_photos.rb
+++ b/db/migrate/20170828011420_change_column_type_to_photos.rb
@@ -1,9 +1,9 @@
 class ChangeColumnTypeToPhotos < ActiveRecord::Migration[5.0]
  def up
-  	change_column :photos, :listing_id, :integer, null: false
+  	change_column :photos, :listing_id, :integer, null: false, foreign_key: :true
   end
 
   def down
-  	change_column :photos, :listing_id, :string, null: false
+  	change_column :photos, :listing_id, :string
   end
 end


### PR DESCRIPTION
### 概要
herokuでのdb migrateでコケる不具合に関して、原因と思われるmigrationファイルを削除し、
既存ファイルを修正しました。

原因は、誤った記載のされたmigrationファイルをプロジェクトから削除していなかったことで、
migration時にそのファイルが読み込まれてエラーとなっていました。
→以前にid系のカラムに対してNOT NULLを追加した際に誤った修正migrationファイルを作成し、そのまま消されずに残っていた（誤った修正migrationファイルに対する、修正版migrationファイルは作成していた）。

- エラー内容(そもそも削除すべきファイルが読み込まれたタイミングで発生)
> == 20170816144352 AddAttachmentImageToPhotos: migrating =======================
> -- change_table(:photos, {})
> D, [2017-08-31T09:38:48.458456 #19] DEBUG -- :    (488.2ms)  ALTER TABLE "photos" ADD "image_file_name" character varying
> D, [2017-08-31T09:38:48.459984 #19] DEBUG -- :    (1.1ms)  ALTER TABLE "photos" ADD "image_content_type" character varying
> D, [2017-08-31T09:38:48.461301 #19] DEBUG -- :    (1.0ms)  ALTER TABLE "photos" ADD "image_file_size" integer
> D, [2017-08-31T09:38:48.463142 #19] DEBUG -- :    (1.6ms)  ALTER TABLE "photos" ADD "image_updated_at" timestamp
> rake aborted!
> StandardError: An error has occurred, this and all later migrations canceled:
> PG::DatatypeMismatch: ERROR:  foreign key constraint "fk_rails_4208915901" cannot be implemented
> DETAIL:  Key columns "listing_id" and "id" are of incompatible types: character varying and integer.
> : ALTER TABLE "photos" ALTER COLUMN "listing_id" TYPE character varying
> 