### PR TITLE
Delete unnecessary migration file

### DIFF
--- a/db/migrate/20170827142343_change_column_to_photos.rb
+++ b/db/migrate/20170827142343_change_column_to_photos.rb
@@ -1,9 +1,0 @@
-class ChangeColumnToPhotos < ActiveRecord::Migration[5.0]
-  def up
-  	change_column :photos, :listing_id, :string, null: false
-  end
-
-  def down
-  	change_column :photos, :listing_id, :string
-  end
-end

--- a/db/migrate/20170828011420_change_column_type_to_photos.rb
+++ b/db/migrate/20170828011420_change_column_type_to_photos.rb
@@ -4,6 +4,6 @@ class ChangeColumnTypeToPhotos < ActiveRecord::Migration[5.0]
   end
 
   def down
-  	change_column :photos, :listing_id, :string, null: false
+  	change_column :photos, :listing_id, :string
   end
 end


### PR DESCRIPTION
## 概要
heroku上のdb migrateでコケる不具合に関して、原因と思われるmigrationファイルを削除し、
既存ファイルを修正しました。

## 原因
誤った記載のされたmigrationファイルをプロジェクトから削除していなかったことで、
migration時にそのファイルが読み込まれてエラーとなっていました。
→以前にid系のカラムに対してNOT NULLを追加した際に誤った修正migrationファイルを作成し、そのまま消されずに残っていた（誤った修正migrationファイルに対する、修正版migrationファイルは作成していた）。


エラー内容(そもそも削除すべきファイルが読み込まれたタイミングで発生)
```
== 20170816144352 AddAttachmentImageToPhotos: migrating =======================
-- change_table(:photos, {})
D, [2017-08-31T09:38:48.458456 #19] DEBUG -- : (488.2ms) ALTER TABLE "photos" ADD "image_file_name" character varying
D, [2017-08-31T09:38:48.459984 #19] DEBUG -- : (1.1ms) ALTER TABLE "photos" ADD "image_content_type" character varying
D, [2017-08-31T09:38:48.461301 #19] DEBUG -- : (1.0ms) ALTER TABLE "photos" ADD "image_file_size" integer
D, [2017-08-31T09:38:48.463142 #19] DEBUG -- : (1.6ms) ALTER TABLE "photos" ADD "image_updated_at" timestamp
rake aborted!
StandardError: An error has occurred, this and all later migrations canceled:
PG::DatatypeMismatch: ERROR: foreign key constraint "fk_rails_4208915901" cannot be implemented
DETAIL: Key columns "listing_id" and "id" are of incompatible types: character varying and integer.
: ALTER TABLE "photos" ALTER COLUMN "listing_id" TYPE character varying
```